### PR TITLE
fix: scoreboard nonesense

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,7 @@ bukkit { // Options: https://github.com/Minecrell/plugin-yml#bukkit
     prefix = project.name
     version = "${project.version}"
     description = "${project.description}"
-    authors = listOf("ShermansWorld")
+    authors = listOf("ShermansWorld", "darksaid98")
     contributors = listOf()
     apiVersion = "1.21"
 

--- a/src/main/java/io/github/alathra/boltux/hook/packetevents/PacketEventsHook.java
+++ b/src/main/java/io/github/alathra/boltux/hook/packetevents/PacketEventsHook.java
@@ -7,6 +7,9 @@ import io.github.alathra.boltux.config.Settings;
 import io.github.alathra.boltux.hook.AbstractHook;
 import io.github.alathra.boltux.hook.Hook;
 import io.github.alathra.boltux.packets.GlowPacketListener;
+import io.github.alathra.boltux.packets.GlowingEntityTracker;
+import io.github.alathra.boltux.packets.TeamTracker;
+import io.github.alathra.boltux.packets.TeamsPacketListener;
 import io.th0rgal.oraxen.api.OraxenItems;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +34,7 @@ public class PacketEventsHook extends AbstractHook {
     public void onEnable(BoltUX plugin) {
         if (!isHookLoaded()) return;
         PacketEvents.getAPI().init();
+        PacketEvents.getAPI().getEventManager().registerListener(new TeamsPacketListener(), PacketListenerPriority.NORMAL);
         PacketEvents.getAPI().getEventManager().registerListener(new GlowPacketListener(), PacketListenerPriority.NORMAL);
     }
 
@@ -38,6 +42,8 @@ public class PacketEventsHook extends AbstractHook {
     public void onDisable(BoltUX plugin) {
         if (!isHookLoaded()) return;
         PacketEvents.getAPI().terminate();
+        TeamTracker.getInstance().clear();
+        GlowingEntityTracker.getInstance().clear();
     }
 
     public @Nullable ItemStack getLockItem() {

--- a/src/main/java/io/github/alathra/boltux/listener/ListenerHandler.java
+++ b/src/main/java/io/github/alathra/boltux/listener/ListenerHandler.java
@@ -1,6 +1,7 @@
 package io.github.alathra.boltux.listener;
 
 import io.github.alathra.boltux.BoltUX;
+import io.github.alathra.boltux.hook.Hook;
 import io.github.alathra.boltux.utility.Reloadable;
 
 public class ListenerHandler implements Reloadable {
@@ -20,6 +21,8 @@ public class ListenerHandler implements Reloadable {
         plugin.getServer().getPluginManager().registerEvents(new LockReturnListeners(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new ProtectionDamageListeners(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new ProtectionInteractListeners(), plugin);
+        if (Hook.PacketEvents.isLoaded())
+            plugin.getServer().getPluginManager().registerEvents(new PacketEventsListeners(), plugin);
     }
 
     @Override

--- a/src/main/java/io/github/alathra/boltux/listener/LockUseListeners.java
+++ b/src/main/java/io/github/alathra/boltux/listener/LockUseListeners.java
@@ -10,6 +10,7 @@ import io.github.alathra.boltux.hook.Hook;
 import io.github.alathra.boltux.hook.quickshop.QuickShopHook;
 import io.github.alathra.boltux.packets.GlowingBlock;
 import io.github.alathra.boltux.packets.GlowingEntity;
+import io.github.alathra.boltux.packets.GlowingEntityTracker;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -180,8 +181,7 @@ public class LockUseListeners implements Listener {
         }
 
         if (Hook.PacketEvents.isLoaded()) {
-            GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-            glowingEntity.glow(NamedTextColor.GREEN);
+            new GlowingEntity(entity, player, NamedTextColor.GREEN);
         }
 
         if (Settings.isLockingSoundEnabled()) {
@@ -256,8 +256,7 @@ public class LockUseListeners implements Listener {
         }
 
         if (Hook.PacketEvents.isLoaded()) {
-            GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-            glowingEntity.glow(NamedTextColor.GREEN);
+            new GlowingEntity(entity, player, NamedTextColor.GREEN);
         }
 
         if (Settings.isLockingSoundEnabled()) {

--- a/src/main/java/io/github/alathra/boltux/listener/PacketEventsListeners.java
+++ b/src/main/java/io/github/alathra/boltux/listener/PacketEventsListeners.java
@@ -1,0 +1,12 @@
+package io.github.alathra.boltux.listener;
+
+import io.github.alathra.boltux.packets.GlowingEntityTracker;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PacketEventsListeners implements Listener {
+    @SuppressWarnings("unused")
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        GlowingEntityTracker.getInstance().untrack(e.getPlayer());
+    }
+}

--- a/src/main/java/io/github/alathra/boltux/listener/ProtectionDamageListeners.java
+++ b/src/main/java/io/github/alathra/boltux/listener/ProtectionDamageListeners.java
@@ -7,6 +7,7 @@ import io.github.alathra.boltux.data.MaterialGroups;
 import io.github.alathra.boltux.hook.Hook;
 import io.github.alathra.boltux.packets.GlowingBlock;
 import io.github.alathra.boltux.packets.GlowingEntity;
+import io.github.alathra.boltux.packets.GlowingEntityTracker;
 import io.github.alathra.boltux.utility.BlockUtil;
 import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -121,11 +122,7 @@ public class ProtectionDamageListeners implements Listener {
 
         // Make entity glow red if player does not have access
         if (!canBreak) {
-            if (GlowingEntity.glowingEntitiesRawMap.containsKey(entity.getEntityId())) {
-                return;
-            }
-            GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-            glowingEntity.glow(NamedTextColor.RED);
+            new GlowingEntity(entity, player, NamedTextColor.RED);
         }
     }
 
@@ -155,11 +152,7 @@ public class ProtectionDamageListeners implements Listener {
         // Make entity glow red if player does not have access
         if (!canBreak) {
             if (Hook.PacketEvents.isLoaded()) {
-                if (GlowingEntity.glowingEntitiesRawMap.containsKey(entity.getEntityId())) {
-                    return;
-                }
-                GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-                glowingEntity.glow(NamedTextColor.RED);
+                new GlowingEntity(entity, player, NamedTextColor.RED);
             }
         }
     }
@@ -192,11 +185,7 @@ public class ProtectionDamageListeners implements Listener {
         // Make entity glow red if player does not have access
         if (!canBreak) {
             if (Hook.PacketEvents.isLoaded())  {
-                if (GlowingEntity.glowingEntitiesRawMap.containsKey(entity.getEntityId())) {
-                    return;
-                }
-                GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-                glowingEntity.glow(NamedTextColor.RED);
+                new GlowingEntity(entity, player, NamedTextColor.RED);
             }
         }
     }

--- a/src/main/java/io/github/alathra/boltux/listener/ProtectionInteractListeners.java
+++ b/src/main/java/io/github/alathra/boltux/listener/ProtectionInteractListeners.java
@@ -10,6 +10,7 @@ import io.github.alathra.boltux.hook.Hook;
 import io.github.alathra.boltux.hook.packetevents.PacketEventsHook;
 import io.github.alathra.boltux.packets.GlowingBlock;
 import io.github.alathra.boltux.packets.GlowingEntity;
+import io.github.alathra.boltux.packets.GlowingEntityTracker;
 import io.github.alathra.boltux.utility.BlockUtil;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -168,11 +169,7 @@ public class ProtectionInteractListeners implements Listener {
         // Make entity glow red if player does not have access
         if (!canAccess) {
             if (Hook.PacketEvents.isLoaded()) {
-                if (GlowingEntity.glowingEntitiesRawMap.containsKey(entity.getEntityId())) {
-                    return;
-                }
-                GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-                glowingEntity.glow(NamedTextColor.RED);
+                new GlowingEntity(entity, player, NamedTextColor.RED);
             }
         }
     }
@@ -220,11 +217,7 @@ public class ProtectionInteractListeners implements Listener {
         // Make entity glow red if player does not have access
         if (!canAccess) {
             if (Hook.PacketEvents.isLoaded()) {
-                if (GlowingEntity.glowingEntitiesRawMap.containsKey(entity.getEntityId())) {
-                    return;
-                }
-                GlowingEntity glowingEntity = new GlowingEntity(entity, player);
-                glowingEntity.glow(NamedTextColor.RED);
+                new GlowingEntity(entity, player, NamedTextColor.RED);
             }
         }
     }

--- a/src/main/java/io/github/alathra/boltux/packets/GlowingEntityTracker.java
+++ b/src/main/java/io/github/alathra/boltux/packets/GlowingEntityTracker.java
@@ -1,0 +1,66 @@
+package io.github.alathra.boltux.packets;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks all glowing entities for a player. Used to prevent duplicate glowing entities.
+ * @author darksaid98
+ */
+public class GlowingEntityTracker {
+    private static GlowingEntityTracker INSTANCE = null;
+
+    public static GlowingEntityTracker getInstance() {
+        if (INSTANCE == null)
+            INSTANCE = new GlowingEntityTracker();
+        return INSTANCE;
+    }
+
+    private GlowingEntityTracker() {
+    }
+
+    private final Map<Player, Set<UUID>> glowingEntities = new ConcurrentHashMap<>();
+
+    public void track(Player player, Entity entity) {
+        glowingEntities.compute(player, (player1, uuids) -> {
+            if (uuids != null) {
+                uuids.add(entity.getUniqueId());
+                return uuids;
+            }
+
+            final Set<UUID> set = ConcurrentHashMap.newKeySet();
+            set.add(entity.getUniqueId());
+            return set;
+        });
+    }
+
+    public void untrack(Player player) {
+        glowingEntities.remove(player);
+    }
+
+    public void untrack(Player player, Entity entity) {
+        glowingEntities.computeIfPresent(player, (player1, uuids) -> {
+            uuids.remove(entity.getUniqueId());
+            return uuids;
+        });
+        if (glowingEntities.containsKey(player) && glowingEntities.get(player).isEmpty())
+            glowingEntities.remove(player);
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public boolean isGlowing(Player player, Entity entity) {
+        return Optional.ofNullable(glowingEntities.get(player))
+            .map(uuids -> uuids.contains(entity.getUniqueId()))
+            .orElse(false);
+    }
+
+    public void clear() {
+        glowingEntities.clear();
+    }
+}

--- a/src/main/java/io/github/alathra/boltux/packets/TeamTracker.java
+++ b/src/main/java/io/github/alathra/boltux/packets/TeamTracker.java
@@ -1,0 +1,45 @@
+package io.github.alathra.boltux.packets;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Used to track whether an entity is in a scoreboard team or not.
+ * @author darksaid98
+ */
+public class TeamTracker {
+    private static TeamTracker INSTANCE = null;
+
+    public static TeamTracker getInstance() {
+        if (INSTANCE == null)
+            INSTANCE = new TeamTracker();
+        return INSTANCE;
+    }
+
+    private TeamTracker() {}
+
+    private final Map<UUID, NamedTextColor> entityMap = new ConcurrentHashMap<>();
+
+    public void setTracked(UUID uuid, NamedTextColor color) {
+        entityMap.put(uuid, color);
+    }
+
+    public void unTrack(UUID uuid) {
+        entityMap.remove(uuid);
+    }
+
+    public NamedTextColor getTrackedColor(UUID uuid) {
+        return entityMap.get(uuid);
+    }
+
+    public boolean isTracked(UUID uuid) {
+        return entityMap.containsKey(uuid);
+    }
+
+    public void clear() {
+        entityMap.clear();
+    }
+}

--- a/src/main/java/io/github/alathra/boltux/packets/TeamsPacketListener.java
+++ b/src/main/java/io/github/alathra/boltux/packets/TeamsPacketListener.java
@@ -1,0 +1,21 @@
+package io.github.alathra.boltux.packets;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.UserLoginEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+/**
+ * Creates all scoreboard teams used by the plugin for each player on login.
+ * @author darksaid98
+ */
+public class TeamsPacketListener implements PacketListener {
+    @Override
+    public void onUserLogin(UserLoginEvent event) {
+        final Player player = event.getPlayer();
+
+        // Pre-create teams used by the plugin
+        TeamsPacketUtil.createTeam(player, NamedTextColor.GREEN);
+        TeamsPacketUtil.createTeam(player, NamedTextColor.RED);
+    }
+}

--- a/src/main/java/io/github/alathra/boltux/packets/TeamsPacketUtil.java
+++ b/src/main/java/io/github/alathra/boltux/packets/TeamsPacketUtil.java
@@ -1,0 +1,112 @@
+package io.github.alathra.boltux.packets;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A class for managing/interacting with scoreboard teams using PacketEvents.
+ * @author darksaid98
+ */
+final class TeamsPacketUtil {
+    /**
+     * Generates a team name based on the team color
+     * @param color the team color
+     * @return team name
+     */
+    private static String getTeamName(NamedTextColor color) {
+        return "boltux_color_" + color.toString();
+    }
+
+    /**
+     * Generates a team-info object based on the team color
+     * @param color the team color
+     * @return team info
+     */
+    private static WrapperPlayServerTeams.ScoreBoardTeamInfo getTeamInfo(NamedTextColor color) {
+        return new WrapperPlayServerTeams.ScoreBoardTeamInfo(
+            Component.empty(),
+            Component.empty(),
+            Component.empty(),
+            WrapperPlayServerTeams.NameTagVisibility.NEVER,
+            WrapperPlayServerTeams.CollisionRule.NEVER,
+            color,
+            WrapperPlayServerTeams.OptionData.NONE
+        );
+    }
+
+    /**
+     * Creates a team containing the player and team color.
+     * @param player the player
+     * @param color the team color
+     * @implNote The player is automatically added to this team.
+     */
+    public static void createTeam(Player player, NamedTextColor color) {
+        PacketEvents.getAPI().getPlayerManager().sendPacket(
+            player,
+            new WrapperPlayServerTeams(
+                getTeamName(color),
+                WrapperPlayServerTeams.TeamMode.CREATE,
+                getTeamInfo(color),
+                List.of(String.valueOf(PacketEvents.getAPI().getPlayerManager().getUser(player).getUUID()))
+            )
+        );
+    }
+
+    /**
+     * Removes a team.
+     * @param player the player
+     * @param color the team color
+     */
+    public static void removeTeam(Player player, NamedTextColor color) {
+        PacketEvents.getAPI().getPlayerManager().sendPacket(
+            player,
+            new WrapperPlayServerTeams(
+                getTeamName(color),
+                WrapperPlayServerTeams.TeamMode.REMOVE,
+                getTeamInfo(color)
+            )
+        );
+    }
+
+    /**
+     * Adds a collection of entity {@link java.util.UUID}s to the team members list.
+     * @param player the player
+     * @param color the team color
+     * @param entities the collection of {@link java.util.UUID}s
+     */
+    public static void addToTeam(Player player, NamedTextColor color, Collection<String> entities) {
+        PacketEvents.getAPI().getPlayerManager().sendPacket(
+            player,
+            new WrapperPlayServerTeams(
+                getTeamName(color),
+                WrapperPlayServerTeams.TeamMode.ADD_ENTITIES,
+                getTeamInfo(color),
+                entities
+            )
+        );
+    }
+
+    /**
+     * Removes a collection of entity {@link java.util.UUID}s from the team members list.
+     * @param player the player
+     * @param color the team color
+     * @param entities the collection of {@link java.util.UUID}s
+     */
+    public static void removeFromTeam(Player player, NamedTextColor color, Collection<String> entities) {
+        PacketEvents.getAPI().getPlayerManager().sendPacket(
+            player,
+            new WrapperPlayServerTeams(
+                getTeamName(color),
+                WrapperPlayServerTeams.TeamMode.REMOVE_ENTITIES,
+                getTeamInfo(color),
+                entities
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR includes a few improvements and fixes.

# General overview:
- uses packets to handle teams
- fixes silly entity interact hack patch
- fixes concurrency issues

# Scoreboard Teams:
## Issue
As mentioned, there is absolutely no reason to use the Bukkit API for scoreboard teams. Not only are all players added to each team, but we're adding ephemeral (unsynced) entities to them as well, which is synchronized to clients from the server. 

It makes no sense that any client be made aware of entity UUIDs that aren't real. And as shown, this oversight in design and (ab)use of the Bukkit/Minecraft scoreboard API can cause severe issues.

## Packet-Based Approach
All used custom scoreboard teams are created and sent on **PlayerJoin** to each player, including only the relevant player as a team member.

When spawning or de-spawning fake entities, instead of ab(using) Bukkit API. We manually send the Add or Remove packets to the client, in order to add or remove our fake entities from the teams.

# Concurrency
Particularly in `GlowPacketListener`, data structures that make no guarantees are being accessed and mutated on the fly. Generally, all new API and changes introduced have been made thread-safe.

# GlowPacketListener _(Again)_
## Problem
When a client interacts with an entity, it requests an update to the entity. The server then sends it's copy of the entity's metadata **(which does not include our glow attribute)**. This would cause the entity to stop glowing if right-clicked.

The old fix was to just create a new glow on every interaction (Which is problematic, as said interactions also spawn runnables and are high-frequency events).

## Solution
The solution is simple. Listen for the client-bound packet updating the entity metadata. Then modify and include the glow attribute in the outgoing packet.

This means the glow state remains unchanged on the client.

It is a much better solution than sending **override** packets, resulting in packet spam and races.
